### PR TITLE
Import sp_core and sp_runtime directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ blake2b_simd = "0.5.10"
 base64 = "0.12.3"
 regex = "1.3.9"
 sp-arithmetic = "2.0.0-rc6"
+sp-core =  "2.0.0-rc6"
+sp-runtime =  "2.0.0-rc6"
 
 [profile.release]
 lto = "fat"

--- a/src/approved_validators.rs
+++ b/src/approved_validators.rs
@@ -21,7 +21,7 @@ use super::{keyparse::{parse_public, parse_secret},
             AccountId, Error, Ss58AddressFormat, StructOpt, KEY_MAGIC, KEY_VERSION};
 use ed25519_dalek::Keypair;
 use std::{fs::OpenOptions, io::Write, os::unix::fs::OpenOptionsExt, path::PathBuf};
-use substrate_subxt::sp_core::H256;
+use sp_core::H256;
 
 #[derive(StructOpt, Debug)]
 pub(crate) enum ACL {

--- a/src/common.rs
+++ b/src/common.rs
@@ -17,8 +17,8 @@
 //! Utilities shared by both validator and nominator code
 
 use super::{AccountId, AccountType, Error, LedgeracioPath};
-use substrate_subxt::{sp_core::crypto::{Ss58AddressFormat, Ss58Codec},
-                      system::AccountStoreExt,
+use sp_core::crypto::{Ss58AddressFormat, Ss58Codec};
+use substrate_subxt::{system::AccountStoreExt,
                       Client, KusamaRuntime, Properties, Signer};
 
 pub(crate) async fn fetch_validators(

--- a/src/derivation.rs
+++ b/src/derivation.rs
@@ -16,7 +16,8 @@
 
 //! Polkadot and Kusama derivation paths
 
-use substrate_subxt::sp_core::crypto::Ss58AddressFormat;
+// use substrate_subxt::sp_core::crypto::Ss58AddressFormat;
+use sp_core::crypto::Ss58AddressFormat;
 use zx_bip44::BIP44Path;
 
 /// A derivation path that can be used with Ledgeracio

--- a/src/hardstore.rs
+++ b/src/hardstore.rs
@@ -24,10 +24,9 @@ use super::{Encode, Error, LedgeracioPath};
 use codec::Decode;
 use ledger_substrate::SubstrateApp;
 use std::{future::Future, pin::Pin, sync::Arc};
-use substrate_subxt::{sp_core::crypto::{AccountId32 as AccountId, Ss58AddressFormat},
-                      sp_runtime::{generic::{SignedPayload, UncheckedExtrinsic},
-                                   MultiSignature},
-                      system::System,
+use sp_core::crypto::{AccountId32 as AccountId, Ss58AddressFormat};
+use sp_runtime::{generic::{SignedPayload, UncheckedExtrinsic}, MultiSignature};
+use substrate_subxt::{system::System,
                       Encoded, Runtime, SignedExtra};
 
 /// Hardware keystore

--- a/src/keyparse.rs
+++ b/src/keyparse.rs
@@ -21,7 +21,7 @@ use ed25519_dalek::{ExpandedSecretKey, Keypair, PublicKey};
 use regex::bytes::Regex;
 use std::{convert::{TryFrom, TryInto},
           str};
-use substrate_subxt::sp_core::crypto::Ss58AddressFormat;
+use sp_core::crypto::Ss58AddressFormat;
 
 /// Parse a Ledgeracio secret key file
 pub(crate) fn parse_secret(secret: &[u8], network: Ss58AddressFormat) -> Result<Keypair, Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,14 +40,13 @@ use hardstore::HardStore;
 compile_error!("Only *nix-like platforms are supported");
 
 use common::AddressSource;
-use sp_core::crypto::AccountId32 as AccountId;
 use std::{convert::{TryFrom, TryInto},
           fmt::Debug,
           future::Future,
           pin::Pin};
 use structopt::StructOpt;
-use substrate_subxt::{sp_core,
-                      sp_core::crypto::{Ss58AddressFormat, Ss58Codec},
+use sp_core::{self, crypto::{AccountId32 as AccountId, Ss58AddressFormat, Ss58Codec}};
+use substrate_subxt::{
                       staking::RewardDestination,
                       Client, ClientBuilder, Signer};
 

--- a/src/nominator.rs
+++ b/src/nominator.rs
@@ -19,9 +19,8 @@
 use super::{parse_address, parse_reward_destination, AccountType, Error, LedgeracioPath, StructOpt};
 use crate::common::pad;
 use core::{future::Future, pin::Pin};
-use substrate_subxt::{sp_core::{crypto::{AccountId32 as AccountId, Ss58AddressFormat, Ss58Codec},
-                                H256},
-                      staking::{BondedStore, LedgerStore, NominateCallExt, PayeeStore,
+use sp_core::{crypto::{AccountId32 as AccountId, Ss58AddressFormat, Ss58Codec}, H256};
+use substrate_subxt::{staking::{BondedStore, LedgerStore, NominateCallExt, PayeeStore,
                                 RewardDestination, SetPayeeCallExt},
                       Client, KusamaRuntime};
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -19,7 +19,7 @@
 use ed25519_dalek::{ExpandedSecretKey, PublicKey};
 use std::{convert::TryFrom,
           io::{prelude::*, Error, ErrorKind}};
-use substrate_subxt::sp_core::crypto::{AccountId32 as AccountId, Ss58AddressFormat, Ss58Codec};
+use sp_core::crypto::{AccountId32 as AccountId, Ss58AddressFormat, Ss58Codec};
 
 pub fn parse<T: BufRead, U: Ss58Codec>(
     reader: T,
@@ -146,7 +146,7 @@ mod tests {
    5GQvjFcJBCGTFeb2hvtQ9yRfbDNQajLJbW1yzgCra5uUTLvn
 5Cw8KtiVsBx4AK9SCzAMmXvprJiYuhRYwDUA4WHJ55ghYgYL
 5EhBPkiqA1rkoFZL6o87bSpgfTptHzp6nE3VkH4dRUed1Qdh
-5G3uDdTW8MeGW1QZR9FeZuN1exiVJZnUJ9ovyJexubiytNUj     
+5G3uDdTW8MeGW1QZR9FeZuN1exiVJZnUJ9ovyJexubiytNUj
 5FbtadyFPdDZMiLYjdEwAyFqavVwzYueEYX8Z6fsL4UrxTXx
 5ENTEF2sAtM89XxdwRxwSKDF7hxX9udy7zdr2G4i8bRdbBH9
 5EWgCx3UMqzYt9vSf7GCHd2jhRUYF7GqVNeyPjpXxGkLV7b4

--- a/src/payouts.rs
+++ b/src/payouts.rs
@@ -21,9 +21,9 @@ use futures::{future::join3,
               stream::{FuturesUnordered, StreamExt as _}};
 use log::trace;
 use std::marker::PhantomData;
-use substrate_subxt::{sp_core::crypto::AccountId32 as AccountId,
-                      sp_runtime::traits::Zero,
-                      staking::{CurrentEraStore, ErasRewardPointsStore, HistoryDepthStore,
+use sp_core::crypto::AccountId32 as AccountId;
+use sp_runtime::traits::Zero;
+use substrate_subxt::{staking::{CurrentEraStore, ErasRewardPointsStore, HistoryDepthStore,
                                 LedgerStore, StakingLedger},
                       Client, KusamaRuntime};
 

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -18,10 +18,9 @@ use super::{parse_address, parse_reward_destination, AccountType, AddressSource,
             LedgeracioPath, StructOpt};
 use codec::Decode;
 use core::{future::Future, pin::Pin};
+use sp_core::{crypto::{AccountId32 as AccountId, Ss58AddressFormat}, H256};
+use sp_runtime::Perbill;
 use substrate_subxt::{session::SetKeysCallExt,
-                      sp_core::{crypto::{AccountId32 as AccountId, Ss58AddressFormat},
-                                H256},
-                      sp_runtime::Perbill,
                       staking::{BondedStore, RewardDestination, SetPayeeCallExt, ValidateCallExt,
                                 ValidatorPrefs},
                       Client, KusamaRuntime, SessionKeys};


### PR DESCRIPTION
Before this PR we use the re-exports from `substrate-subxt`. Changing to use the crates directly takes the first timid steps towards decoupling `ledgeracio` from `substrate-subxt` and makes it clearer whence the imports come. It also has the disadvantage that types may mismatch in the future.

Really on the fence if this is a good idea or not.