### PR TITLE
Switch to the Signify public key format

### DIFF
--- a/src/bin/ledgeracio-allowlist/keyparse.rs
+++ b/src/bin/ledgeracio-allowlist/keyparse.rs
@@ -87,7 +87,7 @@ pub(crate) fn parse_public(unparsed: &[u8]) -> Result<(PublicKey, Ss58AddressFor
         base64::decode_config_slice(&*data, base64::STANDARD, &mut pk)?,
         pk.len()
     );
-    if &pk[..2] != &b"Ed"[..] {
+    if pk[..2] != b"Ed"[..] {
         return Err("bad magic number in base64".to_owned().into())
     }
     let pk = ed25519_dalek::PublicKey::from_bytes(&pk[10..])?;

--- a/src/bin/ledgeracio-allowlist/main.rs
+++ b/src/bin/ledgeracio-allowlist/main.rs
@@ -192,15 +192,17 @@ async fn really_inner_main<T: FnOnce() -> Result<ledgeracio::HardStore, Error>>(
             let keypair = Keypair::generate(&mut rand::rngs::OsRng {});
             let secretkey = keypair.secret.to_bytes();
             let publickey = keypair.public.to_bytes();
+            let mut thevec = b"Edaaaaaaaa"[..].to_owned();
+            thevec.extend(publickey[..].iter());
             file.set_extension("pub");
             let public = format!(
-                "Ledgeracio version 1 public key for network {}\n{}\n",
+                "untrusted comment: Ledgeracio v2 network {} public key\n{}\n",
                 match network {
                     Ss58AddressFormat::KusamaAccount => "Kusama",
                     Ss58AddressFormat::PolkadotAccount => "Polkadot",
                     _ => unreachable!("should have been rejected earlier"),
                 },
-                base64::encode(&publickey[..])
+                base64::encode(&thevec[..])
             );
             write(&[public.as_bytes()], &file)?;
             file.set_extension("sec");


### PR DESCRIPTION
The secret key format *has not* been switched, as it is not
standardized.